### PR TITLE
feat: replace chalk with `styleText` utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,14 @@
 {
   "name": "@j9t/imagemin-guard",
-  "version": "4.0.6",
+  "version": "4.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@j9t/imagemin-guard",
-      "version": "4.0.6",
+      "version": "4.1.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "^5.4.1",
         "filesize": "^10.1.6",
         "gifsicle": "^7.0.1",
         "globby": "^14.1.0",
@@ -2748,9 +2747,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001649",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001649.tgz",
-      "integrity": "sha512-fJegqZZ0ZX8HOWr6rcafGr72+xcgJKI9oWfDW5DrD7ExUtgZC7a7R7ZYmZqplh7XDocFdGeIFn7roAxhOeYrPQ==",
+      "version": "1.0.30001700",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
+      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
       "dev": true,
       "funding": [
         {
@@ -2781,17 +2780,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/char-regex": {
@@ -8808,9 +8796,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001649",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001649.tgz",
-      "integrity": "sha512-fJegqZZ0ZX8HOWr6rcafGr72+xcgJKI9oWfDW5DrD7ExUtgZC7a7R7ZYmZqplh7XDocFdGeIFn7roAxhOeYrPQ==",
+      "version": "1.0.30001700",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
+      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
       "dev": true
     },
     "caw": {
@@ -8823,11 +8811,6 @@
         "tunnel-agent": "^0.6.0",
         "url-to-options": "^1.0.1"
       }
-    },
-    "chalk": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.4.1.tgz",
-      "integrity": "sha512-zgVZuo2WcZgfUEmsn6eO3kINexW8RAE4maiQ8QNs8CtpPCSyMiYsULR3HQYkm3w8FIA3SberyMJMSldGsW+U3w=="
     },
     "char-regex": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@j9t/imagemin-guard",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@j9t/imagemin-guard",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "filesize": "^10.1.6",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "imagemin-merlin": "bin/imagemin-guard.js"
   },
   "dependencies": {
-    "chalk": "^5.4.1",
     "filesize": "^10.1.6",
     "gifsicle": "^7.0.1",
     "globby": "^14.1.0",
@@ -42,5 +41,5 @@
     "test": "jest"
   },
   "type": "module",
-  "version": "4.0.6"
+  "version": "4.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "test": "jest"
   },
   "type": "module",
-  "version": "4.1.0"
+  "version": "4.1.1"
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
 // This file, which had been forked from imagemin-merlin, was modified for imagemin-guard: https://github.com/sumcumo/imagemin-merlin/compare/master...j9t:master
 
-import { utils } from './utils.js'
-import chalk from 'chalk';
 import { globbySync } from 'globby'
-import simpleGit from 'simple-git'
-import _yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
+import simpleGit from 'simple-git'
+import { styleText } from 'node:util'
+import { utils } from './utils.js'
+import _yargs from 'yargs'
 
 (async () => {
   const yargs = _yargs(hideBin(process.argv))
@@ -14,9 +14,9 @@ import { hideBin } from 'yargs/helpers'
   // Share status
   const summary = (run) => {
     if (run) {
-      console.info(chalk.bold(`\nDefensive base compression completed. You saved ${utils.sizeReadable(savedKB)}.`))
+      console.info(styleText(['bold'], `\nDefensive base compression completed. You saved ${utils.sizeReadable(savedKB)}.`))
     } else {
-      console.info(chalk.bold('There were no images to compress.'))
+      console.info(styleText(['bold'], 'There were no images to compress.'))
     }
   }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,16 +1,24 @@
 // This file, which had been forked from imagemin-merlin, was modified for imagemin-guard: https://github.com/sumcumo/imagemin-merlin/compare/master...j9t:master
 
-import chalk from 'chalk'
 import { execFile } from 'child_process'
 import fs from 'fs'
 import gifsicle from 'gifsicle'
 import os from 'os'
 import path from 'path'
 import sharp from 'sharp'
+import { styleText } from 'node:util'
 import util from 'util'
 
 const logMessage = (message, dry, color = 'yellow') => {
-  console.info(chalk[color](`${dry ? 'Dry run: ' : ''}${message}`))
+  const logMessageStyled = (color) => styleText(color, `${dry ? 'Dry run: ' : ''}${message}`)
+  const styles = {
+    yellow: logMessageStyled('yellow'),
+    red: logMessageStyled('red'),
+    green: logMessageStyled('green'),
+    blue: logMessageStyled('blue'),
+    white: logMessageStyled('white'),
+  }
+  console.info(styles[color])
 }
 
 const compression = async (filename, dry) => {
@@ -18,7 +26,7 @@ const compression = async (filename, dry) => {
   try {
     await fs.promises.copyFile(filename, filenameBackup)
   } catch (error) {
-    console.error(chalk.red(`Error creating backup for ${filename}:`), error)
+    console.error(styleText('red', `Error creating backup for ${filename}:`, { stream: stderr }), error)
     return 0
   }
 
@@ -102,14 +110,14 @@ const compression = async (filename, dry) => {
     await fs.promises.unlink(tempFilePath)
 
     if (fileSizeAfter === 0) {
-      console.error(chalk.red(`Error compressing ${filename}: Compressed file size is 0`))
+      console.error(styleText('red', `Error compressing ${filename}: Compressed file size is 0`, { stream: stderr }))
     }
 
     return fileSizeAfter < fileSizeBefore ? fileSizeBefore - fileSizeAfter : 0
 
   } catch (error) {
 
-    console.error(chalk.red(`Error compressing ${filename}:`), error)
+    console.error(styleText('red', `Error compressing ${filename}:`, { stream: stderr }), error)
     await fs.promises.rename(filenameBackup, filename)
     return 0
 
@@ -119,7 +127,7 @@ const compression = async (filename, dry) => {
       await fs.promises.unlink(filenameBackup)
     } catch (error) {
       if (error.code !== 'ENOENT') {
-        console.warn(chalk.yellow(`Failed to delete backup file ${filenameBackup}:`), error)
+        console.warn(styleText('yellow', `Failed to delete backup file ${filenameBackup}:`, { stream: stderr }), error)
       }
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,15 +10,8 @@ import { styleText } from 'node:util'
 import util from 'util'
 
 const logMessage = (message, dry, color = 'yellow') => {
-  const logMessageStyled = (color) => styleText(color, `${dry ? 'Dry run: ' : ''}${message}`)
-  const styles = {
-    yellow: logMessageStyled('yellow'),
-    red: logMessageStyled('red'),
-    green: logMessageStyled('green'),
-    blue: logMessageStyled('blue'),
-    white: logMessageStyled('white'),
-  }
-  console.info(styles[color])
+  const prefix = dry ? 'Dry run: ' : ''
+  console.info(styleText(color, `${prefix}${message}`))
 }
 
 const compression = async (filename, dry) => {
@@ -26,7 +19,7 @@ const compression = async (filename, dry) => {
   try {
     await fs.promises.copyFile(filename, filenameBackup)
   } catch (error) {
-    console.error(styleText('red', `Error creating backup for ${filename}:`, { stream: stderr }), error)
+    console.error(styleText('red', `Error creating backup for ${filename}:`), error)
     return 0
   }
 
@@ -110,14 +103,14 @@ const compression = async (filename, dry) => {
     await fs.promises.unlink(tempFilePath)
 
     if (fileSizeAfter === 0) {
-      console.error(styleText('red', `Error compressing ${filename}: Compressed file size is 0`, { stream: stderr }))
+      console.error(styleText('red', `Error compressing ${filename}: Compressed file size is 0`))
     }
 
     return fileSizeAfter < fileSizeBefore ? fileSizeBefore - fileSizeAfter : 0
 
   } catch (error) {
 
-    console.error(styleText('red', `Error compressing ${filename}:`, { stream: stderr }), error)
+    console.error(styleText('red', `Error compressing ${filename}:`), error)
     await fs.promises.rename(filenameBackup, filename)
     return 0
 
@@ -127,7 +120,7 @@ const compression = async (filename, dry) => {
       await fs.promises.unlink(filenameBackup)
     } catch (error) {
       if (error.code !== 'ENOENT') {
-        console.warn(styleText('yellow', `Failed to delete backup file ${filenameBackup}:`, { stream: stderr }), error)
+        console.warn(styleText('yellow', `Failed to delete backup file ${filenameBackup}:`), error)
       }
     }
   }


### PR DESCRIPTION
Replaced the chalk library with the built-in styleText utility, improving maintainability and reducing external dependencies. Updated related code for logging and text styling, and incremented the package version to 4.1.0.

(This commit message was AI-generated.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated the project version and streamlined dependency management by removing the `chalk` dependency.

- **Style**
  - Improved the formatting of console messages to provide a more consistent and visually cohesive experience by replacing the previous styling method with `styleText`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->