### PR TITLE
chore: bump version to 4.1.4 and fix linting issues

### DIFF
--- a/bin/imagemin-guard.test.js
+++ b/bin/imagemin-guard.test.js
@@ -73,9 +73,9 @@ describe('Imagemin Guard', () => {
   afterAll(() => {
     // Clean up temporary directory
     if (fs.existsSync(testFolderGit)) {
-      fs.rmSync(testFolderGit, { recursive: true, force: true });
+      fs.rmSync(testFolderGit, { recursive: true, force: true })
     }
-  });
+  })
 
   test('Compress images', () => {
     // Ensure images in temp folder are not already compressed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@j9t/imagemin-guard",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@j9t/imagemin-guard",
-      "version": "4.1.3",
+      "version": "4.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "filesize": "^10.1.6",

--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "test": "jest"
   },
   "type": "module",
-  "version": "4.1.3"
+  "version": "4.1.4"
 }


### PR DESCRIPTION
Updated the version in package files to 4.1.4. Removed unnecessary semicolons in test cleanup code to address linting consistency.

(This commit message was AI-generated.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the package to version 4.1.4.
- **Tests**
  - Refined cleanup routines in the test suite for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->