### PR TITLE
Docs: Add troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ export PATH="node_modules/.bin:$PATH"
 npx imagemin-guard --staged
 ```
 
-The issue may arise because certain clients or editors may not inherit your shell’s `PATH`/Node environment, whether using native Git hooks or Husky. (This affects any tool using npx in hooks.)
+The issue can arise in GUI Git clients (VS Code, GitHub Desktop, etc.) or with Node version managers, as these environments may not inherit your shell's `PATH`/Node environment. (This affects any tool using npx in hooks.)
 
 ## What Does the Output Look Like?
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ npm pkg set scripts.postprepare="grep -qxF 'npx imagemin-guard --staged' .husky/
 
 #### “npx: command not found”
 
-If Git hooks fail with “npx: command not found,” make sure to install (`npm i -D @j9t/imagemin-guard`) and use the binary directly:
+If Git hooks fail with “npx: command not found,” make sure to install (`npm i -D @j9t/imagemin-guard`) and to refer to the binary directly in both `pre-commit` hook and `postprepare` script:
 
 ```console
 #!/bin/sh

--- a/README.md
+++ b/README.md
@@ -116,12 +116,12 @@ npm pkg set scripts.postprepare="grep -qxF 'npx imagemin-guard --staged' .husky/
 
 #### “npx: command not found”
 
-If Git hooks fail with “npx: command not found,” consider adding the `PATH` directly to your hook:
+If Git hooks fail with “npx: command not found,” make sure to install (`npm i -D @j9t/imagemin-guard`) and use the binary directly:
 
-```bash
+```console
 #!/bin/sh
-export PATH="node_modules/.bin:$PATH"
-npx imagemin-guard --staged
+export PATH="$PWD/node_modules/.bin:$PATH"
+./node_modules/.bin/imagemin-guard --staged
 ```
 
 The issue can arise in GUI Git clients (VS Code, GitHub Desktop, etc.) or with Node version managers, as these environments may not inherit your shell's `PATH`/Node environment. (This affects any tool using npx in hooks.)

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ npm pkg set scripts.postprepare="grep -qxF 'npx imagemin-guard --staged' .husky/
 
 #### “npx: command not found”
 
-If Git hooks fail with “npx: command not found,” make sure to install (`npm i -D @j9t/imagemin-guard`) and to refer to the binary directly in both `pre-commit` hook and `postprepare` script:
+If Git hooks fail with “npx: command not found,” make sure to install (`npm i -D @j9t/imagemin-guard`) and to refer to the binary directly in the `pre-commit` hook (and, not detailed here, also in the `postprepare` script):
 
 ```console
 #!/bin/sh
@@ -124,7 +124,7 @@ export PATH="$PWD/node_modules/.bin:$PATH"
 ./node_modules/.bin/imagemin-guard --staged
 ```
 
-The issue can arise in GUI Git clients (VS Code, GitHub Desktop, etc.) or with Node version managers, as these environments may not inherit your shell's `PATH`/Node environment. (This affects any tool using npx in hooks.)
+This issue can arise in GUI Git clients (VS Code, GitHub Desktop, etc.) or with Node version managers, as these environments may not inherit your shell's `PATH`/Node environment. This affects any tool using npx in hooks.
 
 ## What Does the Output Look Like?
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,20 @@ npm pkg set scripts.postprepare="grep -qxF 'npx imagemin-guard --staged' .husky/
 
 * `--staged` (recommended with automated use) triggers a mode that watches PNG, JPG, GIF, WebP, and AVIF files in `git diff` and only compresses those files—that approach makes Imagemin Guard more efficient in operation.
 
+### Troubleshooting
+
+#### “npx: command not found”
+
+If Git hooks fail with “npx: command not found,” consider adding the `PATH` directly to your hook:
+
+```bash
+#!/bin/sh
+export PATH="node_modules/.bin:$PATH"
+npx imagemin-guard --staged
+```
+
+The issue may arise because certain clients or editors may not inherit your shell’s `PATH`/Node environment, whether using native Git hooks or Husky. (This affects any tool using npx in hooks.)
+
 ## What Does the Output Look Like?
 
 Roughly like this:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Troubleshooting subsection addressing “npx: command not found” in Git hooks.
  * Advises installing the package and referencing the binary directly in hook scripts.
  * Provides a shell example for adjusting PATH so npx is available.
  * Notes GUI Git clients and Node version managers may not inherit PATH/Node environments.
  * Clarifies these are documentation-only updates; no functional changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->